### PR TITLE
Add on-criteria-changed callback to search-directive

### DIFF
--- a/src/modules/components/forms-and-errors/search/search.component.spec.ts
+++ b/src/modules/components/forms-and-errors/search/search.component.spec.ts
@@ -6,6 +6,7 @@ describe('components/forms-and-errors/search', () => {
   let element: any;
   let input: any;
   let controller: any;
+  let formController: any;
 
   beforeEach(angular.mock.module(formsErrors));
 
@@ -14,7 +15,8 @@ describe('components/forms-and-errors/search', () => {
       scope = $rootScope.$new();
       element = $compile(html)(scope);
       input = element.find('input');
-      controller = element.data('$govSearchController');
+      formController = element.data('$formController');
+      controller = element.children().data('$govSearchController');
       scope.$digest();
     });
   }
@@ -26,8 +28,16 @@ describe('components/forms-and-errors/search', () => {
     return <any> event;
   }
 
+  function mockFormController(options) {
+    formController.criteria.$viewValue = options.$viewValue;
+    formController.criteria.$valid = options.$valid;
+    formController.criteria.$invalid = !options.$valid;
+    formController.$valid = options.$valid;
+    formController.$invalid = !options.$valid;
+  }
+
   it('there is a two-way binding between the outer and inner ng-model', () => {
-    compile('<gov-search ng-model="model"></gov-search>');
+    compile('<form><gov-search ng-model="model"></gov-search></form>');
     // outer -> inner
     scope.model = 'foo';
     scope.$digest();
@@ -38,7 +48,7 @@ describe('components/forms-and-errors/search', () => {
   });
 
   it('invokes the `on-search` callback when the search button is clicked', () => {
-    compile('<gov-search ng-model="model" on-search="callback($event)"></gov-search>');
+    compile('<form><gov-search ng-model="model" on-search="callback($criteria)"></gov-search></form>');
     let text = null;
     scope.model = 'foo';
     scope.callback = str => text = str;
@@ -48,7 +58,7 @@ describe('components/forms-and-errors/search', () => {
   });
 
   it('invokes the `on-search` callback when the enter key is pressed', () => {
-    compile('<gov-search ng-model="model" on-search="callback($event)"></gov-search>');
+    compile('<form><gov-search ng-model="model" on-search="callback($criteria)"></gov-search></form>');
     let text = null;
     scope.model = 'foo';
     scope.callback = str => text = str;
@@ -59,7 +69,7 @@ describe('components/forms-and-errors/search', () => {
   });
 
   it('disables the `on-search` callback when the model is invalid', () => {
-    compile('<gov-search required ng-model="model" on-search="callback($event)"></gov-search>');
+    compile('<form><gov-search required ng-model="model" on-search="callback($criteria)"></gov-search></form>');
     let called = false;
     scope.callback = str => called = true;
     element.find('button').triggerHandler('click');
@@ -68,8 +78,46 @@ describe('components/forms-and-errors/search', () => {
     expect(called).toBe(false);
   });
 
+  it('invokes `on-criteria-change` callback when the model IS NOT VALID', () => {
+    compile('<form><gov-search name="criteria" ng-minlength="3" ng-model="model" on-criteria-change="callback($criteria, $valid)"></gov-search></form>');
+    let isValid = undefined, criteria = undefined;
+
+    scope.callback = (_criteria, _isValid) => {
+        isValid = _isValid;
+        criteria = _criteria;
+    };
+    mockFormController({
+        $viewValue: 'fa',
+        $valid: false
+    });
+
+    element.find('button').triggerHandler('click');
+
+    expect(isValid).toBe(false);
+    expect(criteria).toBe('fa');
+  });
+
+  it('invokes `on-criteria-change` callback when the model IS VALID', () => {
+    compile('<form><gov-search name="criteria" ng-model="model" on-criteria-change="callback($criteria, $valid)"></gov-search></form>');
+    let isValid = undefined, criteria = undefined;
+
+    scope.callback = (_criteria, _isValid) => {
+      isValid = _isValid;
+      criteria = _criteria;
+    };
+    mockFormController({
+      $viewValue: 'foo',
+      $valid: true
+    });
+
+    element.find('button').triggerHandler('click');
+
+    expect(isValid).toBe(true);
+    expect(criteria).toBe('foo');
+  });
+
   it('calls revalidate on the lazy validation controller on submit attempt', () => {
-    compile('<gov-search ng-model="model"></gov-search>');
+    compile('<form><gov-search ng-model="model"></gov-search></form>');
     let lazyValidationCtrl = { revalidate: sinon.spy() };
     controller.lazyValidationController = lazyValidationCtrl;
     element.find('button').triggerHandler('click');
@@ -77,40 +125,40 @@ describe('components/forms-and-errors/search', () => {
   });
 
   it('applies the outer `name`, `placeholder` and `autocomplete` attributes to the inner input', () => {
-    compile(`<gov-search name="foo" placeholder="Search" autocomplete="on" ng-model="model"></gov-search>`);
+    compile(`<form><gov-search name="foo" placeholder="Search" autocomplete="on" ng-model="model"></gov-search></form>`);
     expect(element.find('input').attr('name')).toEqual('foo');
     expect(element.find('input').attr('placeholder')).toEqual('Search');
     expect(element.find('input').attr('autocomplete')).toEqual('on');
   });
 
   it('applies the outer `input-id` and `aria-describedby` attributes to the inner input', () => {
-    compile(`<gov-search input-id="inputid" aria-describedby="someid" ng-model="model"></gov-search>`);
+    compile(`<form><gov-search input-id="inputid" aria-describedby="someid" ng-model="model"></gov-search></form>`);
     expect(element.find('input').attr('id')).toEqual('inputid');
     expect(element.find('input').attr('aria-describedby')).toEqual('someid');
   });
 
   it('applies the outer `ng-minlength` attribute to the inner input', () => {
-    compile(`<gov-search ng-minlength="3" ng-model="model"></gov-search>`);
+    compile(`<form><gov-search ng-minlength="3" ng-model="model"></gov-search></form>`);
     expect(element.find('input').attr('ng-minlength')).toEqual('3');
   });
 
   it('applies the gov-search-inline class when inline attribute is set', () => {
-    compile(`<gov-search inline="true" ng-model="model"></gov-search>`);
+    compile(`<form><gov-search inline="true" ng-model="model"></gov-search></form>`);
     expect(element.find('.gov-search-input').hasClass('gov-search-inline')).toBe(true);
   });
 
   it(`doesn't apply the gov-search-inline class when inline attribute is not set`, () => {
-    compile(`<gov-search inline="false" ng-model="model"></gov-search>`);
+    compile(`<form><gov-search inline="false" ng-model="model"></gov-search></form>`);
     expect(element.find('.gov-search-input').hasClass('gov-search-inline')).toBe(false);
   });
 
   it(`applies ng-required attribute to the inner input when the required attribute is set`, () => {
-    compile(`<gov-search required="true" ng-model="model"></gov-search>`);
+    compile(`<form><gov-search required="true" ng-model="model"></gov-search></form>`);
     expect(element.find('input').attr('ng-required')).toEqual('true');
   });
 
   it(`does not apply required attribute to the inner input when the required attribute is not set`, () => {
-    compile(`<gov-search ng-model="model"></gov-search>`);
+    compile(`<form><gov-search ng-model="model"></gov-search></form>`);
     expect(element.find('input').attr('ng-required')).toEqual('');
   });
 });

--- a/src/modules/components/forms-and-errors/search/search.component.ts
+++ b/src/modules/components/forms-and-errors/search/search.component.ts
@@ -4,19 +4,21 @@ import { LazyValidationDirective } from '../lazy-validation/lazy-validation.dire
 @Component({
   template: require('./search.component.html'),
   bindings: {
-    autocomplete:    '@',
-    placeholder:     '@',
-    name:            '@',
-    inputId:         '@',
-    ariaDescribedby: '@',
-    ngModel:         '=',
-    inline:          '<?',
-    ngMinlength:     '@?',
-    required:        '<?',
-    onSearch:        '&'
+    autocomplete:     '@',
+    placeholder:      '@',
+    name:             '@',
+    inputId:          '@',
+    ariaDescribedby:  '@',
+    ngModel:          '=',
+    inline:           '<?',
+    ngMinlength:      '@?',
+    required:         '<?',
+    onSearch:         '&',
+    onCriteriaChange: '&?'
   },
   require: {
     ngModelCtrl: 'ngModel',
+    formCtrl: '^^form',
     lazyValidationController: '^^?lazyValidation'
   }
 })
@@ -25,8 +27,10 @@ export class SearchComponent {
   name: string;
   ngModel: any;
   ngModelCtrl: ng.INgModelController;
+  formCtrl: ng.IFormController;
   lazyValidationController: LazyValidationDirective;
-  onSearch: ($event: {$event: string}) => any;
+  onSearch: ($event: { $criteria: string }) => any;
+  onCriteriaChange: ($event: { $criteria: string, $valid: boolean }) => any;
   inline: boolean;
   required: boolean;
 
@@ -41,7 +45,11 @@ export class SearchComponent {
 
   submit(): void {
     if (this.lazyValidationController) this.lazyValidationController.revalidate();
-    if (this.ngModelCtrl.$valid) this.onSearch({$event: this.ngModel});
+    if (this.onCriteriaChange) this.onCriteriaChange({
+      $criteria: this.formCtrl[this.name].$viewValue,
+      $valid: this.formCtrl.$valid
+    });
+    if (this.ngModelCtrl.$valid) this.onSearch({ $criteria: this.ngModel });
   }
 
   enableSubmitOnEnter(): void {


### PR DESCRIPTION
This required so that we can update URL whenever there's a change to criteria (even to not valid ones) as it's a requirement for accessibility testing (every state accessible with URL)