### PR TITLE
Column navigation

### DIFF
--- a/src/docs/app/components/navigation/navigation.component.html
+++ b/src/docs/app/components/navigation/navigation.component.html
@@ -12,6 +12,7 @@
   <li><a ui-sref="components.navigation({'#': 'gov-side-menu-demo'})">Side Menu</a></li>
   <li><a ui-sref="components.navigation({'#': 'gov-start-bar-demo'})">Start action bar</a></li>
   <li><a ui-sref="components.navigation({'#': 'gov-completed-bar-demo'})">Completed action bar</a></li>
+  <li><a ui-sref="components.navigation({'#': 'gov-column-navigation-demo'})">Column navigation</a></li>
 </ul>
 <section class="docs-section" id="gov-action-pane-demo">
   <gov-action-pane-demo></gov-action-pane-demo>
@@ -36,6 +37,9 @@
 </section>
 <section class="docs-section" id="gov-completed-bar-demo">
   <gov-completed-bar-demo></gov-completed-bar-demo>
+</section>
+<section class="docs-section" id="gov-column-navigation-demo">
+  <gov-column-navigation-demo></gov-column-navigation-demo>
 </section>
 
 

--- a/src/docs/app/components/navigation/navigation.component.html
+++ b/src/docs/app/components/navigation/navigation.component.html
@@ -5,7 +5,7 @@
 <h2 class="heading-small heading-contents">Contents:</h2>
 <ul class="list list-contents">
   <li><a ui-sref="components.navigation({'#': 'gov-action-pane-demo'})">Action pane</a></li>
-  <li><a ui-sref="components.navigation({'#': 'gov-breadcrumbs-demo>'})">Breadcrumbs</a></li>
+  <li><a ui-sref="components.navigation({'#': 'gov-breadcrumbs-demo'})">Breadcrumbs</a></li>
   <li><a ui-sref="components.navigation({'#': 'gov-next-previous-navigation-demo'})">Next/Previous navigation</a></li>
   <li><a ui-sref="components.navigation({'#': 'gov-badge-item-demo'})">Badge Item</a></li>
   <li><a ui-sref="components.navigation({'#': 'gov-top-menu-demo'})">Top Menu</a></li>
@@ -16,7 +16,7 @@
 <section class="docs-section" id="gov-action-pane-demo">
   <gov-action-pane-demo></gov-action-pane-demo>
 </section>
-<section class="docs-section" id="gov-breadcrumbs-demo>">
+<section class="docs-section" id="gov-breadcrumbs-demo">
   <gov-breadcrumbs-demo></gov-breadcrumbs-demo>
 </section>
 <section class="docs-section" id="gov-next-previous-navigation-demo">

--- a/src/modules/components/navigation/breadcrumbs/breadcrumbs.component.html
+++ b/src/modules/components/navigation/breadcrumbs/breadcrumbs.component.html
@@ -1,6 +1,8 @@
 <div class="breadcrumbs">
   <ol>
-    <li><a ui-sref="home">Single Page Platform Development Kit</a></li>
-    <li>Layout</li>
+    <li data-ng-repeat="element in $ctrl.breadcrumbs">
+      <a data-ng-if="element.state" data-ui-sref="{{ element.state }}" data-ng-bind="element.text"></a>
+      <span data-ng-if="!element.state" data-ng-bind="element.text"></span>
+    </li>
   </ol>
 </div>

--- a/src/modules/components/navigation/breadcrumbs/breadcrumbs.component.ts
+++ b/src/modules/components/navigation/breadcrumbs/breadcrumbs.component.ts
@@ -1,6 +1,9 @@
 import { Component } from '@govuk/angularjs-devtools';
 
 @Component({
+  bindings: {
+    breadcrumbs: '<'
+  },
   template: require('./breadcrumbs.component.html')
 })
 export class BreadcrumbsComponent {}

--- a/src/modules/components/navigation/breadcrumbs/breadcrumbs.demo.html
+++ b/src/modules/components/navigation/breadcrumbs/breadcrumbs.demo.html
@@ -1,7 +1,6 @@
 <h2 class="heading-medium">Breadcrumbs</h2>
-<p>This component is using angular-breadcrumb (<span
-    ng-bind-html="'https://github.com/ncuillery/angular-breadcrumb' | linky:'_blank'"></span>), please refer to the link
-  for more information about how to use breadcrumbs.</p>
+<p>Each element of the breadcrumb has a <code>text</code> attribute that defines the text of links and the final element (current page)</p>
+<p>Each of the link elements has a <code>state</code> attribute that takes the state for the link as defined in the $stateProvider routing. In other words it is the same as you would pass to <code>ui-sref</code>.</p>
 
 <gov-tabset>
 
@@ -9,8 +8,9 @@
     <docs-example language="markup">
       <div class="breadcrumbs">
         <ol>
-          <li><a href="#">Single Page Platform Development Kit</a></li>
-          <li>Layout</li>
+          <li><a href="#">Platform Development Kit</a></li>
+          <li><a href="#">Components</a></li>
+          <li>Navigation</li>
         </ol>
       </div>
     </docs-example>
@@ -18,8 +18,30 @@
 
   <gov-tab heading="Angular Markup">
     <docs-example language="markup">
-      <ncy-breadcrumb></ncy-breadcrumb>
+
+      <gov-breadcrumbs breadcrumbs="$ctrl.breadcrumbsData"></gov-breadcrumbs>
+
     </docs-example>
+  </gov-tab>
+  
+  <gov-tab heading="Data">
+    <prismify language="javascript">
+
+      breadcrumbsData = [
+        {
+          state: 'home',
+          text: 'Platform Development Kit',
+        },
+        {
+          state: 'components',
+          text: 'Components'
+        },
+        {
+          text: 'Navigation'
+        }
+      ];
+
+    </prismify>
   </gov-tab>
 
 </gov-tabset>

--- a/src/modules/components/navigation/breadcrumbs/breadcrumbs.demo.ts
+++ b/src/modules/components/navigation/breadcrumbs/breadcrumbs.demo.ts
@@ -3,4 +3,19 @@ import { Component } from '@govuk/angularjs-devtools';
 @Component({
   template: require('./breadcrumbs.demo.html')
 })
-export class BreadcrumbsDemo {}
+export class BreadcrumbsDemo {
+
+  breadcrumbsData = [
+    {
+      state: 'home',
+      text: 'Platform Development Kit'
+    },
+    {
+      state: 'components',
+      text: 'Components'
+    },
+    {
+      text: 'Navigation'
+    }
+  ];
+}

--- a/src/modules/components/navigation/column-navigation/column-navigation-links.component.html
+++ b/src/modules/components/navigation/column-navigation/column-navigation-links.component.html
@@ -1,0 +1,9 @@
+<ul class="related-links">
+  <li data-ng-repeat="link in $ctrl.links">
+    <a href="javascript:void(0);"
+      data-ng-click="link.onClick();"
+      data-ng-class="{'bold-xsmall': link.isBold}" 
+      data-ng-bind="link.text">
+    </a>
+  </li>
+</ul>

--- a/src/modules/components/navigation/column-navigation/column-navigation-links.component.ts
+++ b/src/modules/components/navigation/column-navigation/column-navigation-links.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@govuk/angularjs-devtools';
+
+@Component({
+  bindings: {
+    links: '<'
+  },
+  template: require('./column-navigation-links.component.html')
+})
+export class ColumnNavigationLinksComponent {
+
+  $onInit(): void {
+    console.log('Running');
+  }
+}

--- a/src/modules/components/navigation/column-navigation/column-navigation-related-metadata.component.html
+++ b/src/modules/components/navigation/column-navigation/column-navigation-related-metadata.component.html
@@ -1,0 +1,9 @@
+<p class="related-meta" 
+  data-ng-if="$ctrl.metadata.length === 1"
+  data-ng-bind="$ctrl.metadata[0].text">
+</p>
+<ul class="related-meta"
+  data-ng-if="$ctrl.metadata.length > 1">
+  <li data-ng-repeat="item in $ctrl.metadata" 
+    data-ng-bind="item.text"></li>
+</ul>

--- a/src/modules/components/navigation/column-navigation/column-navigation-related-metadata.component.ts
+++ b/src/modules/components/navigation/column-navigation/column-navigation-related-metadata.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@govuk/angularjs-devtools';
+import { isArray } from 'angular';
+
+@Component({
+  bindings: {
+    metadata: '<'
+  },
+  template: require('./column-navigation-related-metadata.component.html')
+})
+export class ColumnNavigationRelatedMetadataComponent {
+
+  metadata: any;
+
+  $onInit(): void {
+
+    /**
+     * The user can pass in a single metadata object rather than
+     * an array of metadata objects if they want, but it is converted
+     * here to an array.
+     */
+    if(this.metadata && !isArray(this.metadata)) {
+      this.metadata = [this.metadata];
+    }
+  }
+}

--- a/src/modules/components/navigation/column-navigation/column-navigation-section.component.html
+++ b/src/modules/components/navigation/column-navigation/column-navigation-section.component.html
@@ -1,0 +1,4 @@
+<div class="related-section">
+  <h3 class="related-heading" data-ng-if="$ctrl.heading" data-ng-bind="$ctrl.heading"></h3>
+  <div data-ng-transclude></div>
+</div>

--- a/src/modules/components/navigation/column-navigation/column-navigation-section.component.ts
+++ b/src/modules/components/navigation/column-navigation/column-navigation-section.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@govuk/angularjs-devtools';
+
+@Component({
+  bindings: {
+    heading: '<'
+  },
+  transclude: true,
+  template: require('./column-navigation-section.component.html')
+})
+export class ColumnNavigationSectionComponent {}

--- a/src/modules/components/navigation/column-navigation/column-navigation.component.html
+++ b/src/modules/components/navigation/column-navigation/column-navigation.component.html
@@ -1,0 +1,3 @@
+<div class="related">
+  <div data-ng-transclude></div>
+</div>

--- a/src/modules/components/navigation/column-navigation/column-navigation.component.ts
+++ b/src/modules/components/navigation/column-navigation/column-navigation.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@govuk/angularjs-devtools';
+
+@Component({
+  transclude: true,
+  template: require('./column-navigation.component.html')
+})
+export class ColumnNavigationComponent {}

--- a/src/modules/components/navigation/column-navigation/column-navigation.demo.html
+++ b/src/modules/components/navigation/column-navigation/column-navigation.demo.html
@@ -1,0 +1,102 @@
+<h2 class="heading-medium">Column Navigation</h2>
+<p>Component for a column navigation</p>
+
+<gov-tabset>
+
+  <gov-tab heading="HTML Example">
+    <docs-example language="markup">
+
+      <div class="col-sm-4">
+
+        <!-- related -->
+        <div class="related">
+
+          <div class="related-section">
+
+            <ul class="related-links">
+              <li><a href="#">View this user&rsquo;s details</a></li>
+              <li><a href="#">Search for user in this organisation</a></li>
+              <li><a href="#">Search for another organisation</a></li>
+              <li><a class="bold-xsmall" href="#">More</a></li>
+            </ul>
+
+          </div>
+
+        </div>
+        <!-- end -->
+
+      </div>
+
+    </docs-example>
+  </gov-tab>
+
+  <gov-tab heading="Angular Markup">
+    <docs-example language="markup">
+      <div class="col-sm-4">
+        <gov-column-navigation>
+          <gov-column-navigation-section>
+            <gov-column-navigation-links links="$ctrl.example1.column1.links">
+            </gov-column-navigation-links>
+          </gov-column-navigation-section>
+        </gov-column-navigation>
+      </div>
+    </docs-example>
+
+    <docs-example language="markup">
+      <div class="col-sm-4">
+        <gov-column-navigation>
+          <gov-column-navigation-related-metadata metadata="$ctrl.example2.column1.metadata">
+          </gov-column-navigation-related-metadata>
+          <gov-column-navigation-section>
+            <gov-column-navigation-links links="$ctrl.example2.column1.links">
+            </gov-column-navigation-links>
+          </gov-column-navigation-section>
+        </gov-column-navigation>
+      </div>
+      <div class="col-sm-4">
+        <gov-column-navigation>
+          <gov-column-navigation-related-metadata metadata="$ctrl.example2.column2.metadata">
+          </gov-column-navigation-related-metadata>
+          <gov-column-navigation-section>
+            <gov-column-navigation-links links="$ctrl.example2.column2.links">
+            </gov-column-navigation-links>
+          </gov-column-navigation-section>
+        </gov-column-navigation>
+      </div>
+    </docs-example>
+
+    <docs-example language="markup">
+      <div class="col-sm-4">
+        <gov-column-navigation>
+          <gov-column-navigation-section heading="$ctrl.example3.column1.section1heading">
+            <gov-column-navigation-links links="$ctrl.example3.column1.section1links">
+            </gov-column-navigation-links>
+          </gov-column-navigation-section>
+          <gov-column-navigation-section heading="$ctrl.example3.column1.section2heading">
+            <gov-column-navigation-links links="$ctrl.example3.column1.section2links">
+            </gov-column-navigation-links>
+          </gov-column-navigation-section>
+        </gov-column-navigation>
+      </div>
+      <div class="col-sm-4">
+        <gov-column-navigation>
+          <gov-column-navigation-section heading="$ctrl.example3.column2.section1heading">
+            <gov-column-navigation-links links="$ctrl.example3.column2.section1links">
+            </gov-column-navigation-links>
+          </gov-column-navigation-section>
+        </gov-column-navigation>
+      </div>
+    </docs-example>
+  </gov-tab>
+  
+  <gov-tab heading="Data">
+    <prismify language="javascript">
+
+      
+
+    </prismify>
+  </gov-tab>
+
+</gov-tabset>
+
+<discuss-component issue="9"></discuss-component>

--- a/src/modules/components/navigation/column-navigation/column-navigation.demo.ts
+++ b/src/modules/components/navigation/column-navigation/column-navigation.demo.ts
@@ -1,0 +1,141 @@
+import { Component } from '@govuk/angularjs-devtools';
+
+@Component({
+  template: require('./column-navigation.demo.html')
+})
+export class ColumnNavigationDemo {
+
+  example1 = {
+
+    column1: {
+
+      links: [
+        {
+          text: 'View this user\'s details',
+          onClick: function() {
+            console.log('Clicked \"Viewing the user\'s details\"');
+          }
+        },
+        {
+          text: 'Search for user in this organisation',
+          onClick: function() {
+            console.log('Clicked on \"Search for user in this organisation\"');
+          }
+        },
+        {
+          text: 'Search for another organisation',
+          onClick: function() {
+            console.log('Clicked on \"Search for another organisation\"');
+          }
+        },
+        {
+          text: 'More',
+          isBold: true,
+          onClick: function() {
+            console.log('Clicked on \"More\"');
+          }
+        }
+      ]
+    }
+  };
+
+  example2 = {
+
+    column1: {
+
+      metadata: {
+        text: 'This user last signed in on 13 December 2015 at 2:36pm'
+      },
+
+      links: [
+        {
+          text: 'Search for another user',
+          onClick: function() {
+            console.log('Clicked on \"Search for another user\"');
+          }
+        }
+      ]
+    },
+
+    column2: {
+
+      metadata: [
+        {
+          text: 'This user’s account will be suspended on 17 March 2017'
+        },
+        {
+          text: 'This user last signed in on 13 December 2015 at 2:36pm'
+        }
+      ],
+
+      links: [
+        {
+          text: 'Search for another user',
+          onClick: function() {
+            console.log('Clicked on \"Search for another user\"');
+          }
+        }
+      ]
+    }
+  };
+
+  example3 = {
+
+    column1: {
+
+      section1heading: 'Actions for this org',
+
+      section1links: [
+        {
+          text: 'View organisation\'s details',
+          onClick: function() {
+            console.log('Clicked on \"View organisation\'s details\"');
+          }
+        }
+      ],
+
+      section2heading: 'Other actions',
+
+      section2links: [
+        {
+          text: 'Search for another organisation',
+          onClick: function() {
+            console.log('Clicked on \"Search for another organisation\"');
+          }
+        },
+        {
+          text: 'Search all users',
+          onClick: function() {
+            console.log('Clicked on \"Search all users\"');
+          }
+        }
+      ]
+    },
+
+    column2: {
+
+      section1heading: 'To do',
+
+      section1links: [
+        {
+          text: 'View case material',
+          onClick: function() {
+            console.log('Clicked on \"View case material\"');
+          }
+        },
+        {
+          text: 'Enter analysis and charging decisions',
+          onClick: function() {
+            console.log('Clicked on \"Enter analysis and charging decisions\"');
+          }
+        },
+        {
+          text: 'Create action plan',
+          onClick: function() {
+            console.log('Clicked on \"Create action plan\"');
+          }
+        }
+      ],
+    }
+  };
+}

--- a/src/modules/components/navigation/column-navigation/column-navigation.scss
+++ b/src/modules/components/navigation/column-navigation/column-navigation.scss
@@ -1,0 +1,69 @@
+// Related
+// ==========================================================================
+
+$module: 'related';
+
+.#{$module} {
+
+  &-links {
+    @include core-16();
+    margin-top: em(5, 16);
+    margin-bottom: em(20, 16);
+
+    li {
+      margin-bottom: em(12, 16);
+    }
+
+  }
+
+  &-meta {
+    margin-top: 0;
+    margin-bottom: em(10);
+
+    li {
+      border-top: 1px solid $grey-2;
+      margin-bottom: em(10);
+      padding-top: em(10);
+
+      &:first-child {
+        border: 0;
+        padding-top: 0;
+      }
+
+    }
+
+  }
+
+  &-section {
+    overflow: hidden;
+
+    &:first-of-type { // ie9+
+      border-top: em(10) solid $govuk-blue;
+      padding-top: em(5);
+    }
+
+  }
+
+  &-heading {
+    @include bold-24();
+    margin-top: em(5, 24);
+    margin-bottom: em(12, 24);
+  }
+
+}
+
+.related-section:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+
+gov-column-navigation-section:first-of-type .related-section:first-of-type {
+  border-top: em(10) solid $govuk-blue;
+  padding-top: em(5);
+}
+
+/*
+
+HTML Usage
+
+*/

--- a/src/modules/components/navigation/navigation-demos.ts
+++ b/src/modules/components/navigation/navigation-demos.ts
@@ -4,6 +4,7 @@ import docsUtils from '../../../util/docs';
 import { ActionPaneDemo } from './action-pane/action-pane.demo';
 import { BadgeItemDemo} from './badge-item/badge-item.demo';
 import { BreadcrumbsDemo } from './breadcrumbs/breadcrumbs.demo';
+import { ColumnNavigationDemo } from './column-navigation/column-navigation.demo';
 import { CompletedBarDemo} from './completed-bar/completed-bar.demo';
 import { NextPreviousNavigationDemo } from './next-previous-navigation/next-previous-navigation.demo';
 import { SideMenuDemo } from './menus/side-menu/side-menu.demo';
@@ -17,6 +18,7 @@ const module = angular.module('govuk-single-page-pdk.component-demos.navigation'
   .component('govActionPaneDemo', ActionPaneDemo)
   .component('govBadgeItemDemo', BadgeItemDemo)
   .component('govBreadcrumbsDemo', BreadcrumbsDemo)
+  .component('govColumnNavigationDemo', ColumnNavigationDemo)
   .component('govCompletedBarDemo', CompletedBarDemo)
   .component('govNextPreviousNavigationDemo', NextPreviousNavigationDemo)
   .component('govSideMenuDemo', SideMenuDemo)

--- a/src/modules/components/navigation/navigation.scss
+++ b/src/modules/components/navigation/navigation.scss
@@ -2,6 +2,7 @@
 @import "arrow/arrow";
 @import "badge-item/badge-item";
 @import "breadcrumbs/breadcrumbs";
+@import "column-navigation/column-navigation";
 @import "completed-bar/completed-bar";
 @import "menus/side-menu/side-menu";
 @import "menus/top-menu/top-menu";

--- a/src/modules/components/navigation/navigation.ts
+++ b/src/modules/components/navigation/navigation.ts
@@ -2,6 +2,11 @@ import { ActionPaneComponent } from './action-pane/action-pane.component';
 import { ArrowComponent } from './arrow/arrow.component';
 import { BadgeItemComponent} from './badge-item/badge-item.component';
 import { BreadcrumbsComponent } from './breadcrumbs/breadcrumbs.component';
+import { ColumnNavigationComponent } from './column-navigation/column-navigation.component';
+import { ColumnNavigationSectionComponent } from './column-navigation/column-navigation-section.component';
+import { ColumnNavigationLinksComponent } from './column-navigation/column-navigation-links.component';
+import { ColumnNavigationRelatedMetadataComponent }
+                            from './column-navigation/column-navigation-related-metadata.component';
 import { CompletedBarComponent} from './completed-bar/completed-bar.component';
 import { NextPreviousNavigationComponent } from './next-previous-navigation/next-previous-navigation.component';
 import { SideMenuComponent} from './menus/side-menu/side-menu.component';
@@ -15,6 +20,10 @@ const module = angular.module('govuk-single-page-pdk.components.navigation', [])
   .component('govArrow', ArrowComponent)
   .component('govBadgeItem', BadgeItemComponent)
   .component('govBreadcrumbs', BreadcrumbsComponent)
+  .component('govColumnNavigation', ColumnNavigationComponent)
+  .component('govColumnNavigationSection', ColumnNavigationSectionComponent)
+  .component('govColumnNavigationLinks', ColumnNavigationLinksComponent)
+  .component('govColumnNavigationRelatedMetadata', ColumnNavigationRelatedMetadataComponent)
   .component('govCompletedBar', CompletedBarComponent)
   .component('govNextPreviousNavigation', NextPreviousNavigationComponent)
   .component('govSideMenu', SideMenuComponent)

--- a/src/modules/components/navigation/next-previous-navigation/next-previous-navigation.component.html
+++ b/src/modules/components/navigation/next-previous-navigation/next-previous-navigation.component.html
@@ -2,17 +2,17 @@
   
   <div class="pagination-prev">
     <a href="javascript:void(0);" rel="prev" title="$ctrl.navigation.previous.usageInstructions"
-      ng-click="$ctrl.navigation.previous.navigate();">
-      <span class="pagination-label" ng-bind="$ctrl.navigation.previous.name"></span>
-      <span class="pagination-title" ng-bind="$ctrl.navigation.previous.description"></span>
+      data-ng-click="$ctrl.navigation.previous.navigate();">
+      <span class="pagination-label" data-ng-bind="$ctrl.navigation.previous.name"></span>
+      <span class="pagination-title" data-ng-bind="$ctrl.navigation.previous.description"></span>
     </a>
   </div>
   
   <div class="pagination-next">
     <a href="javascript:void(0);" rel="next" title="$ctrl.navigation.next.usageInstructions"
-      ng-click="$ctrl.navigation.next.navigate();">
-      <span class="pagination-label" ng-bind="$ctrl.navigation.next.name"></span>
-      <span class="pagination-title" ng-bind="$ctrl.navigation.next.description"></span>
+      data-ng-click="$ctrl.navigation.next.navigate();">
+      <span class="pagination-label" data-ng-bind="$ctrl.navigation.next.name"></span>
+      <span class="pagination-title" data-ng-bind="$ctrl.navigation.next.description"></span>
     </a>
   </div>
   

--- a/src/modules/components/navigation/start-bar/start-bar.component.html
+++ b/src/modules/components/navigation/start-bar/start-bar.component.html
@@ -1,5 +1,5 @@
 <div class="action-bar action-bar-start">
-  <a class="action-bar-header" href="javascript:void(0);" ng-click="$ctrl.item.click()">
+  <a class="action-bar-header" href="javascript:void(0);" data-ng-click="$ctrl.item.click()">
     <span class="action-bar-title" data-ng-bind="$ctrl.item.description"></span>
   </a>
 </div>

--- a/src/modules/components/navigation/start-bar/start-bar.demo.html
+++ b/src/modules/components/navigation/start-bar/start-bar.demo.html
@@ -62,7 +62,7 @@
     <docs-example language="markup">
 
       <ul class="list">
-        <li ng-repeat="item in $ctrl.items">
+        <li data-ng-repeat="item in $ctrl.items">
           <gov-start-bar item="item"></gov-start-bar>
         </li>
       </ul>


### PR DESCRIPTION
- I've done this declaratively as a number of components so that the order of the sections, and metadata etc can be moved around.

- However, as we can't replace the angular component elements, this is adding extra markup that may not be deemed to be semantically correct.

- Is it possible to add roles to this markup to make it easier for screen-readers to navigate.

- If not, then we can do this in a purely data-driven way but:

1. We won't have the same flexibility to order the sections in as many ways, although we can produce all of the examples so far.

2. Looking at the markup in Trevor's examples, there seems to be html elements such as 
and in the metadata parts. Is it definitely a requirement to be able to render html rather than strings for the metadata, because if so we may need to use transclusion for the metadata with the associated extra angular component elements.