### PR TITLE
Updated block-label directive to handle focusin and focusout events

### DIFF
--- a/src/modules/components/forms-and-errors/directives/block-label.ts
+++ b/src/modules/components/forms-and-errors/directives/block-label.ts
@@ -13,7 +13,9 @@ export class BlockLabelDirective {
 
   $postLink() {
     this.input = this.$element.find('input');
-    this.input.on('focus', () => this.$element.addClass('focused'));
-    this.input.on('blur',  () => this.$element.removeClass('focused'));
+    this.input.on('focus',    () => this.$element.addClass('focused'));
+    this.input.on('focusin',  () => this.$element.addClass('focused'));
+    this.input.on('blur',     () => this.$element.removeClass('focused'));
+    this.input.on('focusout', () => this.$element.removeClass('focused'));
   }
 }

--- a/src/modules/components/forms-and-errors/directives/directives.spec.ts
+++ b/src/modules/components/forms-and-errors/directives/directives.spec.ts
@@ -79,6 +79,11 @@ describe('components/forms-and-errors/directives', () => {
       expect(element.hasClass('focused')).toBe(true);
       element.find('input').triggerHandler('blur');
       expect(element.hasClass('focused')).toBe(false);
+
+      element.find('input').triggerHandler('focusin');
+      expect(element.hasClass('focused')).toBe(true);
+      element.find('input').triggerHandler('focusout');
+      expect(element.hasClass('focused')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
- Updated block-label directive to handle the focusin and focusout events that are used when jQuery overrides jqlite.
- Updated unit tests.