### PR TITLE
components(header): bugfix in header styling

### DIFF
--- a/src/modules/components/headers-and-footers/header/header.scss
+++ b/src/modules/components/headers-and-footers/header/header.scss
@@ -6,9 +6,12 @@
     }
   }
 }
-#wrapper-header {
+
+#header-wrapper {
   #logo {
     background-image: url('#{$govuk-template-image-path}/gov.uk_logotype_crown.png');
+    background-repeat: no-repeat;
+    background-position: 0 0;
     @include ie-lte(8) {
       background-image: url('#{$govuk-template-image-path}/gov.uk_logotype_crown-1x.png');
     }


### PR DESCRIPTION
Changed id selector to reference correct header id and added styling that got lost in the process of overriding background styling from the govuk_template project (background-repeat and background-position).