### PR TITLE
fix(input-number): return null for empty string to address angulars $…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+indent_size = 2
+
+[*.html]
+indent_size = 2
+
+[*.ts]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/modules/components/forms-and-errors/directives/directives.spec.ts
+++ b/src/modules/components/forms-and-errors/directives/directives.spec.ts
@@ -41,6 +41,12 @@ describe('components/forms-and-errors/directives', () => {
       expect(scope.model).toEqual('1');
     });
 
+    it('returns a null value when an empty string is parsed', () => {
+      compile('<input type="text" ng-model="model" input-number>');
+      setValue('');
+      expect(scope.model).toEqual(null);
+    });
+
     it('prevents numbers greater than a nominated max being entered', () => {
       compile('<input type="text" ng-model="model" input-number input-number-max="12">');
       setValue(12);

--- a/src/modules/components/forms-and-errors/directives/input-number.ts
+++ b/src/modules/components/forms-and-errors/directives/input-number.ts
@@ -18,7 +18,7 @@ export class InputNumberDirective {
     inputNumberMin?: string;
     inputNumberMax?: string
     leadingZerosEnabled?: string
-  }) {}
+  }) { }
 
   $onInit() {
     const pad = parseInt(this.$attrs.inputNumberPad, 10);
@@ -26,18 +26,20 @@ export class InputNumberDirective {
 
     // prevent input from containing any non-numeric characters
     this.ngModelCtrl.$parsers.push(val => {
-      val = val.toString();
+      if (val !== null) {
+        val = val.toString();
 
-      let newVal = val.replace(/[^\d]/g, '');
+        let newVal = val.replace(/[^\d]/g, '');
 
-      if (this.$attrs.leadingZerosEnabled === undefined) {
-        newVal = newVal.replace(/\b0+/g, '');
+        if (this.$attrs.leadingZerosEnabled === undefined) {
+          newVal = newVal.replace(/\b0+/g, '');
+        }
+        if (newVal !== val) {
+          this.ngModelCtrl.$setViewValue(newVal);
+          this.ngModelCtrl.$render();
+        }
+        return newVal || null;
       }
-      if (newVal !== val) {
-        this.ngModelCtrl.$setViewValue(newVal);
-        this.ngModelCtrl.$render();
-      }
-      return newVal || undefined;
     });
 
     // prevent any inputs that are greater than any specified max values


### PR DESCRIPTION
Return null value instead of undefined for an empty string
Add .editorconfig for cross editor code formatting